### PR TITLE
Add outdated hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ⚠ This repository is not maintained any more. Please move on to <https://github.com/PhelypeOleinik/lipsum> ⚠
+
 # lipsum
 150 paragraphs of Lorem ipsum dummy text for LaTeX.
 


### PR DESCRIPTION
Could you please add an outdated hint and then flag this repository as archived?

See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/archiving-a-github-repository/archiving-repositories for details on arlchiving.